### PR TITLE
test model csv file variable name and value corrections

### DIFF
--- a/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
@@ -143,7 +143,7 @@ mission:design:cruise_altitude,37500,ft
 mission:design:gross_mass,175400.0,lbm
 mission:design:mach,0.8,unitless
 mission:design:range,3675,NM
-mission:landing:airport_altitude_landing,0,ft
+mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1,s
 mission:landing:glide_to_stall_ratio,1.3,unitless
 mission:landing:maximum_flare_load_factor,1.15,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
@@ -257,10 +257,10 @@ aircraft:wing:wetted_area_scaler,1.0,unitless
 aircraft:wing:wetted_area,2396.56,ft**2
 mission:constraints:max_mach,0.785,unitless
 mission:design:thrust_takeoff_per_eng,28928.1,lbf
-mission:landing:lift_coefficient,2.0,unitless
+mission:landing:lift_coefficient_max,2.0,unitless
 mission:summary:cruise_mach,0.785,unitless
 mission:takeoff:fuel_simple,577,lbm
-mission:takeoff:lift_coefficient,3.0,unitless
+mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 mission:takeoff:rolling_friction_coefficient,0.0175,unitless
 aircraft:fuel:burn_per_passenger_mile,0.1

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm.csv
@@ -140,7 +140,7 @@ mission:design:cruise_altitude,37500,ft
 mission:design:gross_mass,175400,lbm
 mission:design:mach,0.8,unitless
 mission:design:range,3675,NM
-mission:landing:airport_altitude_landing,0,ft
+mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1,s
 mission:landing:glide_to_stall_ratio,1.3,unitless
 mission:landing:maximum_flare_load_factor,1.15,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
@@ -75,7 +75,7 @@ aircraft:landing_gear:fixed_gear,False,unitless
 aircraft:landing_gear:main_gear_location,0.15,unitless
 aircraft:landing_gear:main_gear_mass_coefficient,0.85,unitless
 aircraft:landing_gear:mass_coefficient,0.04,unitless
-aircraft:landing_gear:tail_hook_mass_scaunitlessler,1,unitless
+aircraft:landing_gear:tail_hook_mass_scaler,1,unitless
 aircraft:landing_gear:total_mass_scaler,1,
 aircraft:nacelle:clearance_ratio,0.2,unitless
 aircraft:nacelle:core_diameter_ratio,1.25,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
@@ -141,7 +141,7 @@ mission:design:cruise_altitude,37500,ft
 mission:design:gross_mass,175400,lbm
 mission:design:mach,0.8,unitless
 mission:design:range,3675,NM
-mission:landing:airport_altitude_landing,0,ft
+mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1,s
 mission:landing:glide_to_stall_ratio,1.3,unitless
 mission:landing:maximum_flare_load_factor,1.15,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
@@ -140,7 +140,7 @@ mission:design:cruise_altitude,37500,ft
 mission:design:gross_mass,175400,lbm
 mission:design:mach,0.8,unitless
 mission:design:range,3675,NM
-mission:landing:airport_altitude_landing,0,ft
+mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1,s
 mission:landing:glide_to_stall_ratio,1.3,unitless
 mission:landing:maximum_flare_load_factor,1.15,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
@@ -18,7 +18,7 @@ aircraft:design:drag_increment,0.00175,unitless
 aircraft:design:emergency_equipment_mass,50,lbm
 aircraft:design:max_structural_speed,402.5,mi/h
 aircraft:design:part25_structural_category,3,unitless
-aircraft:design:reserve_fuel_additional,4998,unitless
+aircraft:design:reserve_fuel_additional,4998,lbm
 aircraft:design:static_margin,0.03,unitless
 aircraft:design:structural_mass_increment,0,lbm
 aircraft:design:supercritical_drag_shift,0.033,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
@@ -18,7 +18,7 @@ aircraft:design:drag_increment,0.00175,unitless
 aircraft:design:emergency_equipment_mass,50,lbm
 aircraft:design:max_structural_speed,402.5,mi/h
 aircraft:design:part25_structural_category,3,unitless
-aircraft:design:reserves,4998,unitless
+aircraft:design:reserve_fuel_additional,4998,unitless
 aircraft:design:static_margin,0.03,unitless
 aircraft:design:structural_mass_increment,0,lbm
 aircraft:design:supercritical_drag_shift,0.033,unitless

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_solved.csv
@@ -151,7 +151,7 @@ mission:summary:fuel_flow_scaler,1,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h
-settings:equations_of_motion,solved
+settings:equations_of_motion,solved_2DOF
 settings:mass_method,GASP
 
 # Initial Guesses


### PR DESCRIPTION
### Summary

Updates the variable names and values so that the test .csv files are correctly understood by the load_inputs function.
Tested prob.load_inputs on all 8 .csv files in models/test_aircraft/ and reduced number of 'unused' variables.
Still don't have a translation or correction for the following inputs in these files:

aircraft_for_bench_FwFm.csv
Unused: aircraft:crew_and_payload:num_non_flight_crew [3] 
Unused: aircraft:nacelle:count_factor [2] 

aircraft_for_bench_FwGm.csv
Unused: aircraft:engine:enable_sizing [False] 
Unused: aircraft:crew_and_payload:num_non_flight_crew [3] 
Unused: aircraft:nacelle:count_factor [2] 

aircraft_for_bench_GwFm.csv
Unused: aircraft:crew_and_payload:num_non_flight_crew [3] 
Unused: aircraft:engine:engine_mass_specific [0.21366] 
Unused: aircraft:nacelle:count_factor [2] 

aircraft_for_bench_solved2dof.csv
Unused: aircraft:crew_and_payload:num_non_flight_crew [3] 
Unused: aircraft:nacelle:count_factor [2] 

### Related Issues

- No formal issue created, found during other testing

### Backwards incompatibilities

None

### New Dependencies

None